### PR TITLE
Allow user to customize Reconnection UI and retry parameters

### DIFF
--- a/sample/SampleApp/App.razor
+++ b/sample/SampleApp/App.razor
@@ -1,4 +1,24 @@
-﻿<StatefulReconnection />
+﻿@* Option #1: Default experience, with built-in UI and default reconnection parameters. *@
+<StatefulReconnection />
+
+@* Option #2: Default UI with custom reconnection parameters. *@
+@* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000" /> *@
+
+@* Option #3: Custom UI and reconnection parameters, using Bootstrap classes *@
+@* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000">
+    <ReconnectContent>
+        <div class="d-flex justify-content-center" style="margin-top: 10vh;">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="mb-0">Rejoining the server...</h5>
+                </div>
+                <div class="card-footer d-flex justify-content-center">
+                    <button class="btn btn-primary flex-grow-1" onclick="location.reload()">Reload</button>
+                </div>
+            </div>
+        </div>
+    </ReconnectContent>
+</StatefulReconnection> *@
 
 <Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">

--- a/sample/SampleApp/App.razor
+++ b/sample/SampleApp/App.razor
@@ -4,7 +4,7 @@
 @* Option #2: Default UI with custom reconnection parameters. *@
 @* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000" /> *@
 
-@* Option #3: Custom UI and reconnection parameters, using Bootstrap classes *@
+@* Option #3: Custom UI and reconnection parameters, using Bootstrap classes, as an example. *@
 @* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000">
     <ReconnectContent>
         <div class="d-flex justify-content-center" style="margin-top: 10vh;">

--- a/sample/SampleApp/Pages/Index.razor
+++ b/sample/SampleApp/Pages/Index.razor
@@ -24,13 +24,31 @@ Welcome to your new app.
     </p>
     <p>Textarea: <textarea @bind="someText3"></textarea> [@someText3]</p>
     <p>
-        Radio:
-        <InputRadioGroup @bind-Value="@radioValue">
+        Radio1:
+        <InputRadioGroup @bind-Value="@radioValue1">
             <InputRadio Value="@("Val1")" /> Val1
             <InputRadio Value="@("Val2")" /> Val2
             <InputRadio Value="@("Val3")" /> Val3
         </InputRadioGroup>
-        [@radioValue]
+        [@radioValue1]
+    </p>
+    <p>
+        Radio2:
+        <InputRadioGroup @bind-Value="@radioValue2">
+            <InputRadio Value="@("Val1")" /> Val1
+            <InputRadio Value="@("Val2")" /> Val2
+            <InputRadio Value="@("Val3")" /> Val3
+        </InputRadioGroup>
+        [@radioValue2]
+    </p>
+    <p>
+        Radio3:
+        <InputRadioGroup @bind-Value="@radioValue3">
+            <InputRadio Value="@("Val1")" /> Val1
+            <InputRadio Value="@("Val2")" /> Val2
+            <InputRadio Value="@("Val3")" /> Val3
+        </InputRadioGroup>
+        [@radioValue3]
     </p>
 }
 
@@ -42,7 +60,9 @@ Welcome to your new app.
     string someText3 = "";
     string? selectValue;
     bool checkValue;
-    string? radioValue;
+    string? radioValue1;
+    string? radioValue2;
+    string? radioValue3;
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/StatefulReconnection/StatefulReconnection.razor
+++ b/src/StatefulReconnection/StatefulReconnection.razor
@@ -6,15 +6,34 @@
 @namespace Microsoft.AspNetCore.Components.Web
 
 <div class="reconnect-overlay" @ref="overlay">
-    <div class="reconnect-dialog">
-        <div class="lds-ripple"><div></div><div></div></div>
-        <p>Rejoining the server...</p>
-        <p class="check-internet">Check your internet connection</p>
-        <button onclick="location.reload()" style="display: none">Reload</button>
-    </div>
+    @(ReconnectContent ?? DefaultContent)()
 </div>
 
 @code {
+    [Parameter]
+    public int MaxRetries { get; set; } = 10 * 60; // 10 minutes
+
+    [Parameter]
+    public int RetryIntervalMilliseconds { get; set; } = 1000;
+
+    [Parameter]
+    public RenderFragment? ReconnectContent { get; set; }
+
+    private RenderFragment DefaultContent => __builder =>
+    {
+        <div class="default-content">
+            <div class="lds-ripple"><div></div><div></div></div>
+            <p>Rejoining the server...</p>
+            @if (showCheckInternet)
+            {
+                <p class="check-internet">Check your internet connection</p>
+            }
+            <button onclick="location.reload()" style="display: none">Reload</button>
+        </div>
+    };
+
+    private bool showCheckInternet = false;
+    private Timer? timer;
     private ElementReference overlay;
     private Task<IJSObjectReference> _moduleLoader = default!;
     private bool _disposed;
@@ -34,9 +53,15 @@
             await quiescenceTask;
 
             var module = await _moduleLoader;
+
             if (!_disposed)
             {
-                await module.InvokeVoidAsync("init", overlay);
+                await module.InvokeVoidAsync("init", overlay, MaxRetries, RetryIntervalMilliseconds);
+                timer = new Timer(state =>
+                {
+                    showCheckInternet = true;
+                    InvokeAsync(StateHasChanged);
+                }, null, TimeSpan.FromSeconds(5), Timeout.InfiniteTimeSpan);
             }
         }
     }
@@ -44,5 +69,6 @@
     public void Dispose()
     {
         _disposed = true;
+        timer?.Dispose();
     }
 }

--- a/src/StatefulReconnection/StatefulReconnection.razor
+++ b/src/StatefulReconnection/StatefulReconnection.razor
@@ -5,7 +5,7 @@
 @implements IDisposable
 @namespace Microsoft.AspNetCore.Components.Web
 
-<div class="reconnect-overlay" @ref="overlay">
+<div class="reconnect-overlay" @ref="_overlay">
     @(ReconnectContent ?? DefaultContent)()
 </div>
 
@@ -24,7 +24,7 @@
         <div class="default-content">
             <div class="lds-ripple"><div></div><div></div></div>
             <p>Rejoining the server...</p>
-            @if (showCheckInternet)
+            @if (_showCheckInternet)
             {
                 <p class="check-internet">Check your internet connection</p>
             }
@@ -32,9 +32,9 @@
         </div>
     };
 
-    private bool showCheckInternet = false;
-    private Timer? timer;
-    private ElementReference overlay;
+    private bool _showCheckInternet = false;
+    private Timer? _timer;
+    private ElementReference _overlay;
     private Task<IJSObjectReference> _moduleLoader = default!;
     private bool _disposed;
 
@@ -56,10 +56,10 @@
 
             if (!_disposed)
             {
-                await module.InvokeVoidAsync("init", overlay, MaxRetries, RetryIntervalMilliseconds);
-                timer = new Timer(state =>
+                await module.InvokeVoidAsync("init", _overlay, MaxRetries, RetryIntervalMilliseconds);
+                _timer = new Timer(state =>
                 {
-                    showCheckInternet = true;
+                    _showCheckInternet = true;
                     InvokeAsync(StateHasChanged);
                 }, null, TimeSpan.FromSeconds(5), Timeout.InfiniteTimeSpan);
             }
@@ -69,6 +69,6 @@
     public void Dispose()
     {
         _disposed = true;
-        timer?.Dispose();
+        _timer?.Dispose();
     }
 }

--- a/src/StatefulReconnection/StatefulReconnection.razor.css
+++ b/src/StatefulReconnection/StatefulReconnection.razor.css
@@ -7,61 +7,30 @@
     z-index: 10000;
     display: none;
     animation: reconnect-fade-in;
+    background-color: rgba(0,0,0,0.4);
 }
 
     .reconnect-overlay.reconnect-visible {
         display: block;
     }
 
-    .reconnect-overlay::before {
-        content: '';
-        background-color: rgba(0,0,0,0.4);
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        animation: reconnect-fadeInOpacity 0.5s ease-in-out;
-        opacity: 1;
+    .reconnect-overlay .default-content {
+        position: relative;
+        background-color: white;
+        width: 20rem;
+        margin: 20vh auto;
+        padding: 2rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 3px 6px 2px rgba(0,0,0,0.3);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+        opacity: 0;
+        animation: reconnect-slideUp 1.5s cubic-bezier(.05,.89,.25,1.02) 0.3s, reconnect-fadeInOpacity 0.5s ease-out 0.3s;
+        animation-fill-mode: forwards;
+        z-index: 10001;
     }
-
-    .reconnect-overlay p {
-        margin: 0;
-    }
-
-    .reconnect-overlay button {
-        border: 0;
-        background-color: #6b9ed2;
-        color: white;
-        padding: 4px 24px;
-        border-radius: 4px;
-    }
-
-        .reconnect-overlay button:hover {
-            background-color: #3b6ea2;
-        }
-
-        .reconnect-overlay button:active {
-            background-color: #6b9ed2;
-        }
-
-        .reconnect-dialog {
-            position: relative;
-            background-color: white;
-            width: 20rem;
-            margin: 20vh auto;
-            padding: 2rem;
-            border-radius: 0.5rem;
-            box-shadow: 0 3px 6px 2px rgba(0,0,0,0.3);
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 1rem;
-            opacity: 0;
-            animation: reconnect-slideUp 1.5s cubic-bezier(.05,.89,.25,1.02) 0.3s, reconnect-fadeInOpacity 0.5s ease-out 0.3s;
-            animation-fill-mode: forwards;
-            z-index: 10001;
-        }
 
 .lds-ripple {
     display: block;
@@ -125,6 +94,7 @@
         opacity: 1;
     }
 }
+
 @keyframes reconnect-slideUp {
     0% {
         transform: translateY(30px) scale(0.95);

--- a/src/StatefulReconnection/StatefulReconnection.razor.js
+++ b/src/StatefulReconnection/StatefulReconnection.razor.js
@@ -1,7 +1,7 @@
 ﻿const sessionStorageKey = 'statefulReconnection.uiState';
 let isInitialized;
 
-export function init(overlayElem) {
+export function init(overlayElem, maxRetries, retryIntervalMilliseconds) {
     if (isInitialized) {
         throw new Error('Do not add more than one instance of <StatefulReconnection.Enable>');
     }
@@ -14,13 +14,8 @@ export function init(overlayElem) {
     const origOnConnectionDown = Blazor.defaultReconnectionHandler.onConnectionDown;
     Blazor.defaultReconnectionHandler.onConnectionDown = function(options, error) {
         saveUIState();
-
-        // If no custom options were set, change the defaults
-        if (options.maxRetries === 8 && options.retryIntervalMilliseconds === 20000) {
-            options.retryIntervalMilliseconds = 1000;
-            options.maxRetries = 10 * 60; // 10 minutes
-        }
-
+        options.retryIntervalMilliseconds = retryIntervalMilliseconds;
+        options.maxRetries = maxRetries;
         return origOnConnectionDown.call(this, options, error);
     }
 
@@ -34,24 +29,18 @@ export function init(overlayElem) {
 class BetterReconnectionDisplay {
     constructor(overlayElem) {
         this.overlayElem = overlayElem;
-        this.checkInternetElem = overlayElem.querySelector('.check-internet');
     }
 
     show() {
         this.overlayElem.classList.add('reconnect-visible');
-        this.checkInternetElem.style.display = 'none';
-        clearTimeout(this.showCheckConnectionTimer);
-        this.showCheckConnectionTimer = setTimeout(() => {
-            this.checkInternetElem.style.display = 'block';
-        }, 5000);
     }
 
     update(currentAttempt) {
+        
     }
 
     hide() {
         this.overlayElem.classList.remove('reconnect-visible');
-        clearTimeout(this.showCheckConnectionTimer);
     }
 
     failed() {


### PR DESCRIPTION
- Built on top of PR #2, addressing the radio button logic.
- Allows the user to customize the reconnection parameters (max retries and interval in milliseconds) using parameters.
- Allows the user to customize the reconnection UI, overriding the default.
- Examples provided in App.razor for new abilities to customize.

Intended to resolve #3 