### PR TITLE
Expose reconnection statistics back to the UI

### DIFF
--- a/StatefulReconnection.sln
+++ b/StatefulReconnection.sln
@@ -5,19 +5,16 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4107FF77-98EB-4B5B-AA6F-CFD743E99153}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StatefulReconnection", "src\StatefulReconnection\StatefulReconnection.csproj", "{A9D0EA78-BD14-4324-9735-20B8E2A34F40}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StatefulReconnection", "src\StatefulReconnection\StatefulReconnection.csproj", "{A9D0EA78-BD14-4324-9735-20B8E2A34F40}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sample", "sample", "{6D32E134-D9AB-4049-98AC-CFA02BA91A1F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleApp", "sample\SampleApp\SampleApp.csproj", "{9882F26D-83F3-41C4-A484-679A620DAB42}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleApp", "sample\SampleApp\SampleApp.csproj", "{9882F26D-83F3-41C4-A484-679A620DAB42}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A9D0EA78-BD14-4324-9735-20B8E2A34F40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -29,8 +26,14 @@ Global
 		{9882F26D-83F3-41C4-A484-679A620DAB42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9882F26D-83F3-41C4-A484-679A620DAB42}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{A9D0EA78-BD14-4324-9735-20B8E2A34F40} = {4107FF77-98EB-4B5B-AA6F-CFD743E99153}
 		{9882F26D-83F3-41C4-A484-679A620DAB42} = {6D32E134-D9AB-4049-98AC-CFA02BA91A1F}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D4662359-9CB5-44C6-A0BD-BBCBDF526790}
 	EndGlobalSection
 EndGlobal

--- a/sample/SampleApp/App.razor
+++ b/sample/SampleApp/App.razor
@@ -1,4 +1,24 @@
-﻿<StatefulReconnection />
+﻿@* Option #1: Default experience, with built-in UI and default reconnection parameters. *@
+<StatefulReconnection />
+
+@* Option #2: Default UI with custom reconnection parameters. *@
+@* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000" /> *@
+
+@* Option #3: Custom UI and reconnection parameters, using Bootstrap classes *@
+@* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000">
+    <ReconnectContent>
+        <div class="d-flex justify-content-center" style="margin-top: 10vh;">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="mb-0">Rejoining the server...</h5>
+                </div>
+                <div class="card-footer d-flex justify-content-center">
+                    <button class="btn btn-primary flex-grow-1" onclick="location.reload()">Reload</button>
+                </div>
+            </div>
+        </div>
+    </ReconnectContent>
+</StatefulReconnection> *@
 
 <Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">

--- a/sample/SampleApp/App.razor
+++ b/sample/SampleApp/App.razor
@@ -1,5 +1,5 @@
 ﻿@* Option #1: Default experience, with built-in UI and default reconnection parameters. *@
-<StatefulReconnection />
+@* <StatefulReconnection /> *@
 
 @* Option #2: Default UI with custom reconnection parameters. *@
 @* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000" /> *@
@@ -19,6 +19,9 @@
         </div>
     </ReconnectContent>
 </StatefulReconnection> *@
+
+@* Option #4: Use custom component (based on Option #3).*@
+<CustomStatefulReconnection />
 
 <Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">

--- a/sample/SampleApp/App.razor
+++ b/sample/SampleApp/App.razor
@@ -1,5 +1,5 @@
 ﻿@* Option #1: Default experience, with built-in UI and default reconnection parameters. *@
-@* <StatefulReconnection /> *@
+<StatefulReconnection />
 
 @* Option #2: Default UI with custom reconnection parameters. *@
 @* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000" /> *@
@@ -21,7 +21,7 @@
 </StatefulReconnection> *@
 
 @* Option #4: Use custom component (based on Option #3).*@
-<CustomStatefulReconnection />
+@* <CustomStatefulReconnection /> *@
 
 <Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">

--- a/sample/SampleApp/App.razor
+++ b/sample/SampleApp/App.razor
@@ -4,7 +4,7 @@
 @* Option #2: Default UI with custom reconnection parameters. *@
 @* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000" /> *@
 
-@* Option #3: Custom UI and reconnection parameters, using Bootstrap classes *@
+@* Option #3: Custom UI and reconnection parameters, using Bootstrap classes, as an example. *@
 @* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000">
     <ReconnectContent>
         <div class="d-flex justify-content-center" style="margin-top: 10vh;">

--- a/sample/SampleApp/App.razor
+++ b/sample/SampleApp/App.razor
@@ -1,10 +1,10 @@
-﻿@* Option #1: Default experience, with built-in UI and default reconnection parameters. *@
+﻿@* Example #1: Default experience, with built-in UI and default reconnection parameters. *@
 <StatefulReconnection />
 
-@* Option #2: Default UI with custom reconnection parameters. *@
-@* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000" /> *@
+@* Example #2: Default UI, with custom reconnection parameters. *@
+@* <StatefulReconnection MaxRetries="20" RetryIntervalMilliseconds="1000" /> *@
 
-@* Option #3: Custom UI and reconnection parameters, using Bootstrap classes, as an example. *@
+@* Example #3: Custom UI and reconnection parameters, using Bootstrap classes, as an example. *@
 @* <StatefulReconnection MaxRetries="600" RetryIntervalMilliseconds="1000">
     <ReconnectContent>
         <div class="d-flex justify-content-center" style="margin-top: 10vh;">
@@ -20,8 +20,14 @@
     </ReconnectContent>
 </StatefulReconnection> *@
 
-@* Option #4: Use custom component (based on Option #3).*@
+@* Example #4: Custom component, using bootstrap classes, demonstrating display of reconnection progress,
+               per provided reconnection parameters. This example takes advantage of the optional feedback
+               elements that can be populated by the StatefulReconnection.razor.js script. *@
 @* <CustomStatefulReconnection /> *@
+
+@* Example #5: Another custom component, using a bootstrap modal, demonstrating additional styling and
+               animation, with using Blazor CSS isolation.*@
+@* <AnotherCustomStatefulReconnection /> *@
 
 <Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">

--- a/sample/SampleApp/Pages/Index.razor
+++ b/sample/SampleApp/Pages/Index.razor
@@ -24,13 +24,31 @@ Welcome to your new app.
     </p>
     <p>Textarea: <textarea @bind="someText3"></textarea> [@someText3]</p>
     <p>
-        Radio:
-        <InputRadioGroup @bind-Value="@radioValue">
+        Radio1:
+        <InputRadioGroup @bind-Value="@radioValue1">
             <InputRadio Value="@("Val1")" /> Val1
             <InputRadio Value="@("Val2")" /> Val2
             <InputRadio Value="@("Val3")" /> Val3
         </InputRadioGroup>
-        [@radioValue]
+        [@radioValue1]
+    </p>
+    <p>
+        Radio2:
+        <InputRadioGroup @bind-Value="@radioValue2">
+            <InputRadio Value="@("Val1")" /> Val1
+            <InputRadio Value="@("Val2")" /> Val2
+            <InputRadio Value="@("Val3")" /> Val3
+        </InputRadioGroup>
+        [@radioValue2]
+    </p>
+    <p>
+        Radio3:
+        <InputRadioGroup @bind-Value="@radioValue3">
+            <InputRadio Value="@("Val1")" /> Val1
+            <InputRadio Value="@("Val2")" /> Val2
+            <InputRadio Value="@("Val3")" /> Val3
+        </InputRadioGroup>
+        [@radioValue3]
     </p>
 }
 
@@ -42,7 +60,9 @@ Welcome to your new app.
     string someText3 = "";
     string? selectValue;
     bool checkValue;
-    string? radioValue;
+    string? radioValue1;
+    string? radioValue2;
+    string? radioValue3;
 
     protected override async Task OnInitializedAsync()
     {

--- a/sample/SampleApp/Shared/AnotherCustomStatefulReconnection.razor
+++ b/sample/SampleApp/Shared/AnotherCustomStatefulReconnection.razor
@@ -1,0 +1,24 @@
+﻿<StatefulReconnection MaxRetries=MaxRetries RetryIntervalMilliseconds=RetryIntervalMilliseconds>
+    <ReconnectContent>
+        <div class="modal fade d-block show" tabindex="-1">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h4 class="modal-title">Rejoining the server...</h4>
+                    </div>
+                    <div class="modal-body">
+                        <div class="lds-ripple m-auto"><div></div><div></div></div>
+                    </div>
+                    <div class="modal-footer justify-content-center">
+                        <button type="button" class="btn btn-primary flex-grow-1" onclick="location.reload()">Reload</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </ReconnectContent>
+</StatefulReconnection>
+
+@code {
+    public int MaxRetries { get; set; } = 25;
+    public int RetryIntervalMilliseconds { get; set; } = 1000;
+}

--- a/sample/SampleApp/Shared/AnotherCustomStatefulReconnection.razor.css
+++ b/sample/SampleApp/Shared/AnotherCustomStatefulReconnection.razor.css
@@ -1,36 +1,13 @@
-﻿.reconnect-overlay {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 10000;
-    display: none;
-    animation: reconnect-fade-in;
-    background-color: rgba(0,0,0,0.65);
+﻿.modal {
+    animation: reconnect-fadeInOpacity 0.3s ease-in;
+    border-color: rgba(255, 255, 255, 0.15);
+    border-width: 1px;
+    border-radius: 0.5rem;
 }
 
-    .reconnect-overlay.reconnect-visible {
-        display: block;
-    }
-
-    .reconnect-overlay .default-content {
-        position: relative;
-        background-color: white;
-        width: 20rem;
-        margin: 20vh auto;
-        padding: 2rem;
-        border-radius: 0.5rem;
-        box-shadow: 0 3px 6px 2px rgba(0,0,0,0.3);
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 1rem;
-        opacity: 0;
-        animation: reconnect-slideUp 1.5s cubic-bezier(.05,.89,.25,1.02) 0.3s, reconnect-fadeInOpacity 0.5s ease-out 0.3s;
-        animation-fill-mode: forwards;
-        z-index: 10001;
-    }
+.reconnect-overlay.reconnect-visible .modal-dialog {
+    animation: reconnect-slideDown .5s ease-in-out forwards;
+}
 
 .lds-ripple {
     display: block;
@@ -95,12 +72,12 @@
     }
 }
 
-@keyframes reconnect-slideUp {
+@keyframes reconnect-slideDown {
     0% {
-        transform: translateY(30px) scale(0.95);
+        transform: translateY(-70px);
     }
 
     100% {
-        transform: translateY(0);
+        transform: translateY(70px);
     }
 }

--- a/sample/SampleApp/Shared/CustomStatefulReconnection.razor
+++ b/sample/SampleApp/Shared/CustomStatefulReconnection.razor
@@ -4,7 +4,15 @@
             <div class="card">
                 <div class="card-body text-center">
                     <h5>Rejoining the server...</h5>
-                    <h6 class="mb-0">Retry time remaining: <span id="reconnectRetryTimeRemaining"></span></h6>
+                    <h6>Retry time remaining: <span id="reconnectRetryTimeRemaining"></span></h6>
+                    <div class="mt-3">
+                        <div class="progress" style="height: 20px;">
+                            <div id="reconnectProgressBar" class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="@MaxRetries">
+                                <span><span id="reconnectProgressPercentage"></span>%</span>
+                            </div>
+                        </div>
+                        <small class="form-text text-muted">Attempt: <span id="reconnectRetryCurrentAttempt"></span> out of @MaxRetries</small>
+                    </div>
                 </div>
                 <div class="card-footer d-flex justify-content-center">
                     <button class="btn btn-warning flex-grow-1" onclick="location.reload()">Reload</button>
@@ -15,6 +23,6 @@
 </StatefulReconnection>
 
 @code {
-    public int MaxRetries { get; set; } = 100;
+    public int MaxRetries { get; set; } = 25;
     public int RetryIntervalMilliseconds { get; set; } = 1000;
 }

--- a/sample/SampleApp/Shared/CustomStatefulReconnection.razor
+++ b/sample/SampleApp/Shared/CustomStatefulReconnection.razor
@@ -1,0 +1,20 @@
+﻿<StatefulReconnection MaxRetries=MaxRetries RetryIntervalMilliseconds=RetryIntervalMilliseconds>
+    <ReconnectContent>
+        <div class="d-flex justify-content-center" style="margin-top: 10vh;">
+            <div class="card">
+                <div class="card-body text-center">
+                    <h5>Rejoining the server...</h5>
+                    <h6 class="mb-0">Retry time remaining: <span id="reconnectRetryTimeRemaining"></span></h6>
+                </div>
+                <div class="card-footer d-flex justify-content-center">
+                    <button class="btn btn-warning flex-grow-1" onclick="location.reload()">Reload</button>
+                </div>
+            </div>
+        </div>
+    </ReconnectContent>
+</StatefulReconnection>
+
+@code {
+    public int MaxRetries { get; set; } = 100;
+    public int RetryIntervalMilliseconds { get; set; } = 1000;
+}

--- a/src/StatefulReconnection/StatefulReconnection.razor
+++ b/src/StatefulReconnection/StatefulReconnection.razor
@@ -6,15 +6,34 @@
 @namespace Microsoft.AspNetCore.Components.Web
 
 <div class="reconnect-overlay" @ref="overlay">
-    <div class="reconnect-dialog">
-        <div class="lds-ripple"><div></div><div></div></div>
-        <p>Rejoining the server...</p>
-        <p class="check-internet">Check your internet connection</p>
-        <button onclick="location.reload()" style="display: none">Reload</button>
-    </div>
+    @(ReconnectContent ?? DefaultContent)()
 </div>
 
 @code {
+    [Parameter]
+    public int MaxRetries { get; set; } = 10 * 60; // 10 minutes
+
+    [Parameter]
+    public int RetryIntervalMilliseconds { get; set; } = 1000;
+
+    [Parameter]
+    public RenderFragment? ReconnectContent { get; set; }
+
+    private RenderFragment DefaultContent => __builder =>
+    {
+        <div class="default-content">
+            <div class="lds-ripple"><div></div><div></div></div>
+            <p>Rejoining the server...</p>
+            @if (showCheckInternet)
+            {
+                <p class="check-internet">Check your internet connection</p>
+            }
+            <button onclick="location.reload()" style="display: none">Reload</button>
+        </div>
+    };
+
+    private bool showCheckInternet = false;
+    private Timer? timer;
     private ElementReference overlay;
     private Task<IJSObjectReference> _moduleLoader = default!;
     private bool _disposed;
@@ -34,9 +53,15 @@
             await quiescenceTask;
 
             var module = await _moduleLoader;
+
             if (!_disposed)
             {
-                await module.InvokeVoidAsync("init", overlay);
+                await module.InvokeVoidAsync("init", overlay, MaxRetries, RetryIntervalMilliseconds);
+                timer = new Timer(state =>
+                {
+                    showCheckInternet = true;
+                    InvokeAsync(StateHasChanged);
+                }, null, TimeSpan.FromSeconds(5), Timeout.InfiniteTimeSpan);
             }
         }
     }
@@ -44,5 +69,6 @@
     public void Dispose()
     {
         _disposed = true;
+        timer?.Dispose();
     }
 }

--- a/src/StatefulReconnection/StatefulReconnection.razor
+++ b/src/StatefulReconnection/StatefulReconnection.razor
@@ -5,7 +5,7 @@
 @implements IDisposable
 @namespace Microsoft.AspNetCore.Components.Web
 
-<div class="reconnect-overlay" @ref="overlay">
+<div class="reconnect-overlay" @ref="_overlay">
     @(ReconnectContent ?? DefaultContent)()
 </div>
 
@@ -24,7 +24,7 @@
         <div class="default-content">
             <div class="lds-ripple"><div></div><div></div></div>
             <p>Rejoining the server...</p>
-            @if (showCheckInternet)
+            @if (_showCheckInternet)
             {
                 <p class="check-internet">Check your internet connection</p>
             }
@@ -32,9 +32,9 @@
         </div>
     };
 
-    private bool showCheckInternet = false;
-    private Timer? timer;
-    private ElementReference overlay;
+    private bool _showCheckInternet = false;
+    private Timer? _timer;
+    private ElementReference _overlay;
     private Task<IJSObjectReference> _moduleLoader = default!;
     private bool _disposed;
 
@@ -56,10 +56,10 @@
 
             if (!_disposed)
             {
-                await module.InvokeVoidAsync("init", overlay, MaxRetries, RetryIntervalMilliseconds);
-                timer = new Timer(state =>
+                await module.InvokeVoidAsync("init", _overlay, MaxRetries, RetryIntervalMilliseconds);
+                _timer = new Timer(state =>
                 {
-                    showCheckInternet = true;
+                    _showCheckInternet = true;
                     InvokeAsync(StateHasChanged);
                 }, null, TimeSpan.FromSeconds(5), Timeout.InfiniteTimeSpan);
             }
@@ -69,6 +69,6 @@
     public void Dispose()
     {
         _disposed = true;
-        timer?.Dispose();
+        _timer?.Dispose();
     }
 }

--- a/src/StatefulReconnection/StatefulReconnection.razor
+++ b/src/StatefulReconnection/StatefulReconnection.razor
@@ -6,12 +6,12 @@
 @namespace Microsoft.AspNetCore.Components.Web
 
 <div class="reconnect-overlay" @ref="_overlay">
-    @(ReconnectContent ?? DefaultContent)()
+    @(ReconnectContent ?? DefaultContent)
 </div>
 
 @code {
     [Parameter]
-    public int MaxRetries { get; set; } = 10 * 60; // 10 minutes
+    public int MaxRetries { get; set; } = 600;
 
     [Parameter]
     public int RetryIntervalMilliseconds { get; set; } = 1000;

--- a/src/StatefulReconnection/StatefulReconnection.razor.css
+++ b/src/StatefulReconnection/StatefulReconnection.razor.css
@@ -7,61 +7,30 @@
     z-index: 10000;
     display: none;
     animation: reconnect-fade-in;
+    background-color: rgba(0,0,0,0.4);
 }
 
     .reconnect-overlay.reconnect-visible {
         display: block;
     }
 
-    .reconnect-overlay::before {
-        content: '';
-        background-color: rgba(0,0,0,0.4);
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        animation: reconnect-fadeInOpacity 0.5s ease-in-out;
-        opacity: 1;
+    .reconnect-overlay .default-content {
+        position: relative;
+        background-color: white;
+        width: 20rem;
+        margin: 20vh auto;
+        padding: 2rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 3px 6px 2px rgba(0,0,0,0.3);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+        opacity: 0;
+        animation: reconnect-slideUp 1.5s cubic-bezier(.05,.89,.25,1.02) 0.3s, reconnect-fadeInOpacity 0.5s ease-out 0.3s;
+        animation-fill-mode: forwards;
+        z-index: 10001;
     }
-
-    .reconnect-overlay p {
-        margin: 0;
-    }
-
-    .reconnect-overlay button {
-        border: 0;
-        background-color: #6b9ed2;
-        color: white;
-        padding: 4px 24px;
-        border-radius: 4px;
-    }
-
-        .reconnect-overlay button:hover {
-            background-color: #3b6ea2;
-        }
-
-        .reconnect-overlay button:active {
-            background-color: #6b9ed2;
-        }
-
-        .reconnect-dialog {
-            position: relative;
-            background-color: white;
-            width: 20rem;
-            margin: 20vh auto;
-            padding: 2rem;
-            border-radius: 0.5rem;
-            box-shadow: 0 3px 6px 2px rgba(0,0,0,0.3);
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 1rem;
-            opacity: 0;
-            animation: reconnect-slideUp 1.5s cubic-bezier(.05,.89,.25,1.02) 0.3s, reconnect-fadeInOpacity 0.5s ease-out 0.3s;
-            animation-fill-mode: forwards;
-            z-index: 10001;
-        }
 
 .lds-ripple {
     display: block;
@@ -125,6 +94,7 @@
         opacity: 1;
     }
 }
+
 @keyframes reconnect-slideUp {
     0% {
         transform: translateY(30px) scale(0.95);

--- a/src/StatefulReconnection/StatefulReconnection.razor.js
+++ b/src/StatefulReconnection/StatefulReconnection.razor.js
@@ -1,7 +1,6 @@
 ﻿const sessionStorageKey = 'statefulReconnection.uiState';
 let isInitialized;
 let countdownInterval;
-let remainingTime;
 
 export function init(overlayElem, maxRetries, retryIntervalMilliseconds) {
     if (isInitialized) {
@@ -10,45 +9,49 @@ export function init(overlayElem, maxRetries, retryIntervalMilliseconds) {
 
     isInitialized = true;
     loadUIState();
-    Blazor.defaultReconnectionHandler._reconnectionDisplay = new BetterReconnectionDisplay(overlayElem);
-    remainingTime = maxRetries * retryIntervalMilliseconds;
+    const reconnectionDisplay = new BetterReconnectionDisplay(overlayElem, maxRetries, retryIntervalMilliseconds);
+    Blazor.defaultReconnectionHandler._reconnectionDisplay = reconnectionDisplay;
 
     const origOnConnectionDown = Blazor.defaultReconnectionHandler.onConnectionDown;
-    Blazor.defaultReconnectionHandler.onConnectionDown = function(options, error) {
+    Blazor.defaultReconnectionHandler.onConnectionDown = function (options, error) {
         saveUIState();
         options.retryIntervalMilliseconds = retryIntervalMilliseconds;
         options.maxRetries = maxRetries;
 
+        // If the user has a UI element with id=reconnectRetryMaxAttempts, update it
+        const maxAttemptsElem = document.getElementById("reconnectRetryMaxAttempts");
+        if (maxAttemptsElem) {
+            maxAttemptsElem.textContent = maxRetries;
+        }
+
         // Start countdown timer (exposes countdownInterval to the frontend)
-        const countdownTimerElemCheck = setInterval(function () {
+        countdownInterval = setInterval(() => {
             const countdownTimerElem = document.getElementById("reconnectRetryTimeRemaining");
 
-            // Does the user have a UI element with id=reconnectRetryTimeRemaining?
             if (countdownTimerElem) {
-                countdownInterval = setInterval(() => {
-                    const hours = Math.floor(remainingTime / 3600000);
-                    const minutes = Math.floor((remainingTime % 3600000) / 60000);
-                    const seconds = Math.floor((remainingTime % 60000) / 1000);
-                    countdownTimerElem.textContent = `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+                const avgTimePerRetry = Blazor.defaultReconnectionHandler._reconnectionDisplay.retryDurations.length > 0 ? (Blazor.defaultReconnectionHandler._reconnectionDisplay.retryDurations.reduce((a, b) => a + b, 0) / Blazor.defaultReconnectionHandler._reconnectionDisplay.retryDurations.length) : retryIntervalMilliseconds;
+                Blazor.defaultReconnectionHandler._reconnectionDisplay.remainingTime = (maxRetries - Blazor.defaultReconnectionHandler._reconnectionDisplay.retryDurations.length) * avgTimePerRetry;
 
-                    remainingTime -= 1000;
-                    if (remainingTime < 0) {
-                        clearInterval(countdownInterval);
-                        countdownTimerElem.textContent = "Timeout";
-                    }
-                }, 1000);
-                clearInterval(countdownTimerElemCheck);
+                const hours = Math.floor(Blazor.defaultReconnectionHandler._reconnectionDisplay.remainingTime / 3600000);
+                const minutes = Math.floor((Blazor.defaultReconnectionHandler._reconnectionDisplay.remainingTime % 3600000) / 60000);
+                const seconds = Math.floor((Blazor.defaultReconnectionHandler._reconnectionDisplay.remainingTime % 60000) / 1000);
+                countdownTimerElem.textContent = `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+
+                if (Blazor.defaultReconnectionHandler._reconnectionDisplay.remainingTime < 0) {
+                    clearInterval(countdownInterval);
+                    countdownTimerElem.textContent = "Timeout";
+                }
             }
-        }, 100);
+        }, retryIntervalMilliseconds);
 
         return origOnConnectionDown.call(this, options, error);
     }
 
     const origOnConnectionUp = Blazor.defaultReconnectionHandler.onConnectionUp;
-    Blazor.defaultReconnectionHandler.onConnectionUp = function() {
+    Blazor.defaultReconnectionHandler.onConnectionUp = function () {
         clearUIState();
 
-        // Clear coundown timer
+        // Clear countdown timer
         if (countdownInterval) {
             clearInterval(countdownInterval);
         }
@@ -58,8 +61,13 @@ export function init(overlayElem, maxRetries, retryIntervalMilliseconds) {
 }
 
 class BetterReconnectionDisplay {
-    constructor(overlayElem) {
+    constructor(overlayElem, maxRetries, retryIntervalMilliseconds) {
         this.overlayElem = overlayElem;
+        this.maxRetries = maxRetries;
+        this.retryIntervalMilliseconds = retryIntervalMilliseconds;
+        this.retryDurations = [];
+        this.lastAttemptTimestamp = null;
+        this.remainingTime = maxRetries * retryIntervalMilliseconds;
     }
 
     show() {
@@ -67,7 +75,35 @@ class BetterReconnectionDisplay {
     }
 
     update(currentAttempt) {
-        
+        const currentTime = Date.now();
+
+        // Re-calculate remaining time
+        if (this.lastAttemptTimestamp !== null) {
+            const duration = currentTime - this.lastAttemptTimestamp;
+            this.retryDurations.push(duration);
+        }
+        this.lastAttemptTimestamp = currentTime;
+        const avgTimePerRetry = this.retryDurations.length > 0 ? (this.retryDurations.reduce((a, b) => a + b, 0) / this.retryDurations.length) : this.retryIntervalMilliseconds;
+        this.remainingTime = (this.maxRetries - currentAttempt) * avgTimePerRetry;
+
+        // If the user has a UI element with id=reconnectRetryCurrentAttempt, update it
+        const currentAttemptElem = document.getElementById("reconnectRetryCurrentAttempt");
+        if (currentAttemptElem) {
+            currentAttemptElem.textContent = currentAttempt;
+        }
+
+        // If the user has a UI element with id=reconnectProgressPercentage, update it
+        const reconnectProgressPercentageElem = document.getElementById("reconnectProgressPercentage");
+        if (reconnectProgressPercentageElem) {
+            const progressPercentage = Math.round((currentAttempt / this.maxRetries) * 100);
+            reconnectProgressPercentageElem.textContent = progressPercentage;
+
+            const reconnectProgressBarElem = document.getElementById("reconnectProgressBar");
+            if (reconnectProgressBarElem) {
+                reconnectProgressBarElem.style.width = `${progressPercentage}%`;
+                reconnectProgressBarElem.setAttribute('aria-valuenow', currentAttempt.toString());
+            }
+        }
     }
 
     hide() {
@@ -81,7 +117,7 @@ class BetterReconnectionDisplay {
     rejected() {
         location.reload();
     }
-} 
+}
 
 function loadUIState() {
     const stateJson = sessionStorage.getItem(sessionStorageKey);

--- a/src/StatefulReconnection/StatefulReconnection.razor.js
+++ b/src/StatefulReconnection/StatefulReconnection.razor.js
@@ -48,7 +48,7 @@ export function init(overlayElem, maxRetries, retryIntervalMilliseconds) {
     }
 
     const origOnConnectionUp = Blazor.defaultReconnectionHandler.onConnectionUp;
-    Blazor.defaultReconnectionHandler.onConnectionUp = function () {
+    Blazor.defaultReconnectionHandler.onConnectionUp = function() {
         clearUIState();
 
         // Clear countdown timer

--- a/src/StatefulReconnection/StatefulReconnection.razor.js
+++ b/src/StatefulReconnection/StatefulReconnection.razor.js
@@ -1,7 +1,7 @@
 ﻿const sessionStorageKey = 'statefulReconnection.uiState';
 let isInitialized;
 
-export function init(overlayElem) {
+export function init(overlayElem, maxRetries, retryIntervalMilliseconds) {
     if (isInitialized) {
         throw new Error('Do not add more than one instance of <StatefulReconnection.Enable>');
     }
@@ -14,13 +14,8 @@ export function init(overlayElem) {
     const origOnConnectionDown = Blazor.defaultReconnectionHandler.onConnectionDown;
     Blazor.defaultReconnectionHandler.onConnectionDown = function(options, error) {
         saveUIState();
-
-        // If no custom options were set, change the defaults
-        if (options.maxRetries === 8 && options.retryIntervalMilliseconds === 20000) {
-            options.retryIntervalMilliseconds = 1000;
-            options.maxRetries = 10 * 60; // 10 minutes
-        }
-
+        options.retryIntervalMilliseconds = retryIntervalMilliseconds;
+        options.maxRetries = maxRetries;
         return origOnConnectionDown.call(this, options, error);
     }
 
@@ -34,24 +29,18 @@ export function init(overlayElem) {
 class BetterReconnectionDisplay {
     constructor(overlayElem) {
         this.overlayElem = overlayElem;
-        this.checkInternetElem = overlayElem.querySelector('.check-internet');
     }
 
     show() {
         this.overlayElem.classList.add('reconnect-visible');
-        this.checkInternetElem.style.display = 'none';
-        clearTimeout(this.showCheckConnectionTimer);
-        this.showCheckConnectionTimer = setTimeout(() => {
-            this.checkInternetElem.style.display = 'block';
-        }, 5000);
     }
 
     update(currentAttempt) {
+        
     }
 
     hide() {
         this.overlayElem.classList.remove('reconnect-visible');
-        clearTimeout(this.showCheckConnectionTimer);
     }
 
     failed() {


### PR DESCRIPTION
- Built on top of PRs #2 and #4.
- Intended to resolve #5, and transitively, #1 and #3.
- Expose reconnection statistics back to the UI, should the developer still want to use that information in their custom UI.
- Add various examples for customizing the UI and styling, customizing reconnection parameters, and displaying reconnection/retry statistics.